### PR TITLE
fieldに複数のfilterを設定したときのバグ？の修正

### DIFF
--- a/lib/HTML/Shakan.pm
+++ b/lib/HTML/Shakan.pm
@@ -260,16 +260,10 @@ sub _build_params {
 
         my @val = $self->request->param($name);
         if (@val!=0) {
-            $params->{$name} = @val==1 ? $val[0] : \@val;
-
             if (my $filters = $field->{filters}) {
-                for my $filter (@{$filters}) {
-                    my @val =
-                        ( map { HTML::Shakan::Filters->filter( $filter, $_ ) }
-                            $self->request->param($name) );
-                    $params->{$name} = @val==1 ? $val[0] : \@val;
-                }
+                @val = map { HTML::Shakan::Filters->filter( $filters, $_ ) } @val;
             }
+            $params->{$name} = @val==1 ? $val[0] : \@val;
         }
     }
     $params;

--- a/t/010_core/005_bind_filter.t
+++ b/t/010_core/005_bind_filter.t
@@ -10,7 +10,7 @@ my $form = HTML::Shakan->new(
         TextField(
             name     => 'f',
             required => 1,
-            filters  => ['WhiteSpace']
+            filters  => [qw/WhiteSpace Hiragana/]
         )
     ],
 );


### PR DESCRIPTION
以下のように、filters  => [qw/WhiteSpace Hiragana/]と設定しても、それぞれのフィルターを通らなかったので、通るようにしました。

my $form = HTML::Shakan->new(
    request => CGI->new({f => ' oo ', 'b' => 1}),
    fields => [
        TextField(
            name     => 'f',
            required => 1,
            filters  => [qw/WhiteSpace Hiragana/]
        )
    ],
);
is $form->is_valid(), 1;
is $form->param('f'), 'oo';

よかったら、取り込んでください。
ご確認、よろしくお願いしますっ！！
