### PR TITLE
fix xss of textarea widget

### DIFF
--- a/lib/HTML/Shakan/Widgets/Simple.pm
+++ b/lib/HTML/Shakan/Widgets/Simple.pm
@@ -43,7 +43,7 @@ sub widget_textarea {
     my $value = $form->fillin_param($field->{name}) || '';
     my $attr = {%{$field->attr}}; # shallow copy
     delete $attr->{type}; # textarea tag doesn't need this
-    return '<textarea ' . _attr($attr) . ">${value}</textarea>";
+    return '<textarea ' . _attr($attr) . ">" . HTML::Escape::escape_html($value) . "</textarea>";
 }
 
 sub widget_select {

--- a/t/010_core/003_widgets.t
+++ b/t/010_core/003_widgets.t
@@ -154,4 +154,15 @@ subtest 'widget_input' => sub {
           '<input id="name_field" name="foo_3" type="text" value="0" />';
 };
 
+subtest 'widget_textarea' => sub {
+    my $form_with_value = HTML::Shakan->new(
+        request => query({
+            foo_1 => '</textarea><script>alert("XSS!");</script><textarea>',
+        }),
+        fields => [ ],
+    );
+    is $form->widgets->render($form_with_value, TextField( name => 'foo_1', id => 'name_field', widget => 'textarea')),
+        '<textarea id="name_field" name="foo_1">&lt;/textarea&gt;&lt;script&gt;alert(&quot;XSS!&quot;);&lt;/script&gt;&lt;textarea&gt;</textarea>';
+};
+
 done_testing;


### PR DESCRIPTION
以下のような文字列をフォームに入れると、フォームの表示が崩れて、スクリプトが実行されてしまします。

``` html
</textarea>
<script>alert("XSS!");</script>
<textarea>
```
